### PR TITLE
fix: pinmap definitions

### DIFF
--- a/Inc/pinmap.hpp
+++ b/Inc/pinmap.hpp
@@ -12,9 +12,13 @@
 
 #endif
 
+// clang-format off
+
 namespace PinMap
 {
-static constexpr auto led_pin = uint8_t{3};
-static volatile constexpr uint8_t *led_ddr{&DDRD};
-static volatile constexpr uint8_t *led_port{&PORTD};
+constexpr auto led_pin = uint8_t{3};
+constexpr volatile uint8_t *led_ddr(){ return &DDRD; }
+constexpr volatile uint8_t *led_port() {return &PORTD; }
 } // namespace PinMap
+
+// clang-format on

--- a/Inc/superloop.hpp
+++ b/Inc/superloop.hpp
@@ -1,5 +1,4 @@
-#ifndef SUPERLOOP_HPP
-#define SUPERLOOP_HPP
+#pragma once
 
 #include "utils.hpp"
 
@@ -16,5 +15,3 @@ class Superloop : private Noncopyable
   private:
     uint16_t deadline{0};
 };
-
-#endif // SUPERLOOP_HPP

--- a/Inc/testable_mcu_registers.hpp
+++ b/Inc/testable_mcu_registers.hpp
@@ -1,5 +1,4 @@
-#ifndef TESTABLE_MCU_REGISTERS_HPP
-#define TESTABLE_MCU_REGISTERS_HPP
+#pragma once
 
 #include "stdint.h"
 
@@ -20,5 +19,3 @@ uint8_t TCCR0B;
 #define CS02  (2U)
 #define CS01  (1U)
 #define CS00  (0U)
-
-#endif // TESTABLE_MCU_REGISTERS_HPP

--- a/Inc/timer.hpp
+++ b/Inc/timer.hpp
@@ -1,5 +1,4 @@
-#ifndef TIMER_HPP
-#define TIMER_HPP
+#pragma once
 
 #include "utils.hpp"
 
@@ -24,5 +23,3 @@ class Timer : private Noncopyable
 
     friend void timer_interrupt();
 };
-
-#endif // TIMER_HPP

--- a/Src/superloop.cpp
+++ b/Src/superloop.cpp
@@ -7,7 +7,7 @@ namespace
 {
 constexpr auto TOGGLE_INTERVAL_IN_MS = uint16_t{1'000};
 
-Led led{PinMap::led_pin, PinMap::led_ddr, PinMap::led_port};
+Led led{PinMap::led_pin, PinMap::led_ddr(), PinMap::led_port()};
 Timer timer{};
 } // namespace
 


### PR DESCRIPTION
Fixes `pinmap.hpp` definitions by turning `led_ddr` and `led_port` into `constexpr` functions.

Reference: https://stackoverflow.com/questions/41077173/constexpr-reference-to-avr-port-address